### PR TITLE
Removed hook_cron() due to missing table quant_token

### DIFF
--- a/quant.module
+++ b/quant.module
@@ -197,7 +197,6 @@ function quant_forbidden() {
   die('Forbidden');
 }
 
-
 /**
  * Implements hook_init().
  *
@@ -773,7 +772,7 @@ function _quant_queue_theme_assets() {
   $queue = quant_get_queue();
 
   // Allow modules to provide some files if they need to.
-  drupal_alter('quant_seed_files', $file);
+  drupal_alter('quant_seed_files', $files);
 
   foreach ($files as $file) {
 

--- a/quant.module
+++ b/quant.module
@@ -192,17 +192,6 @@ function quant_menu_local_tasks_alter(&$data, $router_item, $root_path) {
   }
 }
 
-/**
- * Implements hook_cron().
- */
-function quant_cron() {
-  // Tokens can be used multiple times in a single request, this causes issues
-  // with the access check by removing the token clean up to core cron we can
-  // persist a single token for multiple uses, the 1 minute timeout still
-  // ensures that the token will expire naturally.
-  db_query('TRUNCATE {quant_token}');
-}
-
 function quant_forbidden() {
   http_response_code(403);
   die('Forbidden');

--- a/quant.module
+++ b/quant.module
@@ -192,22 +192,10 @@ function quant_menu_local_tasks_alter(&$data, $router_item, $root_path) {
   }
 }
 
-/**
- * Implements hook_cron().
- */
-function quant_cron() {
-  // Tokens can be used multiple times in a single request, this causes issues
-  // with the access check by removing the token clean up to core cron we can
-  // persist a single token for multiple uses, the 1 minute timeout still
-  // ensures that the token will expire naturally.
-  db_query('TRUNCATE {quant_token}');
-}
-
 function quant_forbidden() {
   http_response_code(403);
   die('Forbidden');
 }
-
 
 /**
  * Implements hook_init().


### PR DESCRIPTION
Database table was removed in hook_updat_N, but remained in the module, causing error while running a cron job.
